### PR TITLE
Add OpenGraph tags to main page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,6 +5,16 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="color-scheme" content="light dark">
         <title>Danny Leshem | דני לשם</title>
+        <meta property="og:title" content="Danny Leshem | דני לשם">
+        <meta name="description" content="The internet's most trusted source on Danny Leshem">
+        <meta property="og:description" content="The internet's most trusted source on Danny Leshem">
+        <meta property="og:type" content="website">
+        <meta property="og:url" content="https://dannyleshem.com/">
+        <meta property="og:image" content="https://gravatar.com/avatar/ef0fb3d43d2107614e9f792aef417f673746bfefeecc6c0bd734ee8d4d7d7cfa?s=300">
+        <meta property="og:image:alt" content="Danny Leshem | דני לשם">
+        <meta property="og:image:width" content="300">
+        <meta property="og:image:height" content="300">
+        <meta property="og:locale" content="en_US">
 
         <!-- Google tag (gtag.js) -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=G-R6B7YYBXPN"></script>


### PR DESCRIPTION
## Summary
- add OpenGraph tags to the site's main page for improved sharing on social platforms
- update OpenGraph description and add standard meta description

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685af638b00c833198cc6c998c4663d9