### PR TITLE
Add sitemap.xml and reference it from robots.txt

### DIFF
--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,2 +1,3 @@
 User-agent: *
 Disallow:
+Sitemap: https://dannyleshem.com/sitemap.xml

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://dannyleshem.com/</loc>
+    <lastmod>2025-12-26T21:44:19Z</lastmod>
+  </url>
+  <url>
+    <loc>https://dannyleshem.com/startups.html</loc>
+    <lastmod>2026-02-06T07:53:52Z</lastmod>
+  </url>
+  <url>
+    <loc>https://dannyleshem.com/poems.html</loc>
+    <lastmod>2026-02-20T18:25:27Z</lastmod>
+  </url>
+</urlset>


### PR DESCRIPTION
### Motivation

- Provide a machine-readable sitemap for search engines and ensure crawlers can discover it via `robots.txt`.

### Description

- Add `docs/sitemap.xml` containing URL entries and last modified timestamps for the site homepage and key pages.
- Update `docs/robots.txt` to include a `Sitemap` directive pointing to `https://dannyleshem.com/sitemap.xml`.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3bfc64c0083318cd991d58e298eb9)